### PR TITLE
fix: devcontainer to include envsubst and fix typo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,6 +18,6 @@ RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "$
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends gettext-base
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ If you need to do it once or what to simply try it out, then use the Azure Porta
 
 ### Azure CLI
 
-If you want to automate to repeat the setup and config, then Azure CLI is the way to go.  Unfortunetly, the docs today don't get you all the way there, so I created a script in this repo to help you get it setup. The team is working on fixing that experience, so look at this is a stop gap to help you get going.
+If you want to automate to repeat the setup and config, then Azure CLI is the way to go.  Unfortunately, the docs today don't get you all the way there, so I created a script in this repo to help you get it set up. The team is working on fixing that experience, so look at this as a stop gap to help you get going.
 
 You can find the script here: `./oidc.sh`.
 
-It accepts two parameters:
+It accepts three parameters:
  - APP_NAME - This is the name of the Azure AD app to be created.
  - REPO - This is the repo where you want to setup OIDC.
  - FICS_FILE - This is a path to the file that contains the Federated Identity Credential definitions that you want to create.


### PR DESCRIPTION
Heya!

Thanks for putting this together; I just used it to migrate the publishing mechanism of my Azure Static Web Apps blog: https://github.com/johnnyreilly/blog.johnnyreilly.com/pull/223

I really appreciate you making it easier for me to make this trip.  As I was using it I found the odd typo in the `README.md` which I fixed.  I also discovered that the devcontainer didn't contain the `envsubst` and so I added `gettext` to the mix to solve this.

Thanks again!

BTW you mentioned that this approach is stop gap and better things are in the post.... Do you know what these better things are and when they might arrive?