### PR TITLE
fix: devcontainer envsubst issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
-RUN apt-get update && apt-get install -y --no-install-recommends jq
+RUN apt-get update && apt-get install -y --no-install-recommends jq gettext-base


### PR DESCRIPTION
This PR is a repeat of: https://github.com/jongio/github-azure-oidc/pull/5 and resolves https://github.com/jongio/github-azure-oidc/issues/8

It looks like [this commit](https://github.com/jongio/github-azure-oidc/commit/a4bc6323bc1c3532f5f973ad875a3fc4ea674e66) removed the `gettext-base` package leading to  `error: envsubst: command not found` errors.  This PR adds back the package.

Thanks for your awesome work on this repo!


